### PR TITLE
fix(actions): Wasn't actually emitting the correct actions to the actions Subject

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -9,9 +9,9 @@ export function reduxObservable() {
       if (typeof action === 'function') {
         let obs = from(action(actions, store));
         let sub = obs.subscribe(next);
-        actions.next(action);
         return sub;
       } else {
+        actions.next(action);
         return next(action);
       }
     };


### PR DESCRIPTION
Was instead accidentally emitting only async actions, which is useless.

```diff
if (typeof action === 'function') {
    let obs = from(action(actions, store));
    let sub = obs.subscribe(next);
-   actions.next(action);
    return sub;
  } else {
+   actions.next(action);
    return next(action);
  }
```