### PR TITLE
chore(eslint): more opts for linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "parser": "babel-eslint",
+  "parserOptions": {
+    "sourceType": "module"
+  },
   "rules": {
     // Enforces getter/setter pairs in objects
     "accessor-pairs": 0,


### PR DESCRIPTION
I'm really eager to use this library, so my first step was to try to install it then
tinker with the examples.

However, `npm install` from source requires linting to pass. With a fresh
install, eslint will report a slew of errors.

```
$ npm install

> redux-observable@0.4.0 prepublish /Users/kyle/code/src/github.com/blesh/redux-observable
> npm test

> redux-observable@0.4.0 test /Users/kyle/code/src/github.com/blesh/redux-observable
> npm run build && npm run build_tests && mocha temp

> redux-observable@0.4.0 build /Users/kyle/code/src/github.com/blesh/redux-observable
> npm run lint && rm -rf lib && babel src -d lib

> redux-observable@0.4.0 lint /Users/kyle/code/src/github.com/blesh/redux-observable
> eslint src && eslint test

/Users/kyle/code/src/github.com/blesh/redux-observable/src/ActionsObservable.js
  1:1  error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'

/Users/kyle/code/src/github.com/blesh/redux-observable/src/index.js
  1:1  error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'

/Users/kyle/code/src/github.com/blesh/redux-observable/src/reduxObservable.js
  1:1  error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'

✖ 3 problems (3 errors, 0 warnings)

```

By setting the parserOptions to have `sourceType: 'module'`, the above errors are fixed. This
doesn't take us all the way because it's not having a good time with the ES7 (proposed) bind operator.

```
/Users/kyle/code/src/github.com/blesh/redux-observable/src/ActionsObservable.js
  17:16  error  Parsing error: Unexpected token :
```

I was hoping to figure out how to get eslint to recognize `::`. You'd think that using babel-eslint as
the parser (as is done here) would resolve this. Nope.

Anyways, eager to use the project to get rid of the rx redux mashup we've been working with for a while.

Thanks!