### PR TITLE
chore(devDependencies): lock eslint to v2.9.0 until upstream bug is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
-    "eslint": "^2.8.0",
+    "eslint": "2.9.0",
     "mocha": "^2.4.5",
     "promise": "^7.1.1",
     "redux": "^3.5.1",


### PR DESCRIPTION
eslint/eslint#6158 is the bug.

This fixes #14 until we can upgrade.