### PR TITLE
Adds TypeScript typings, fixes #12

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+import { Middleware } from 'redux';
+import { Observable } from 'rxjs/Observable';
+import { Operator } from 'rxjs/Operator';
+
+export declare function reduxObservable(): Middleware;
+
+// ./node_modules/rxjs/Observable.d.ts
+export declare class ActionsObservable<T> extends Observable<T> {
+
+  // ./node_modules/rxjs/Observable.d.ts specifies an `Observable`'s `source`
+  // property like so: `protected source: Observable<any>;`
+  // since `actionsSubject` is being assigned to an `Observable`'s `source`
+  // property it is being given the type: `Observable<any>`
+  constructor(actionsSubject: Observable<any>);
+
+  // ./node_modules/rxjs/Observable.d.ts specifies operators as generics like so
+  // `protected operator: Operator<any, T>;`
+  lift(operator: Operator<any, T>);
+
+  // ./node_modules/redux/index.d.ts specifies `Action` as having a `type`
+  // property with a type signature of `any`
+  // since `key` is being compared with an `Action`'s `type`, `key` has a type
+  // signature of `any`
+  ofType(key: any);
+}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "lint": "eslint src && eslint test",
     "build": "npm run lint && rm -rf lib && babel src -d lib",
     "build_tests": "rm -rf temp && babel test -d temp",
-    "test": "npm run build && npm run build_tests && mocha temp",
+    "clean": "rimraf ./lib; rimraf ./temp;",
+    "test": "npm run build && npm run build_tests && mocha temp && npm run test_typings",
+    "test_typings": "tsc test/typings.ts --outFile temp/typings.js --target ES2015 --moduleResolution node",
     "prepublish": "npm test"
   },
+  "typings": "./index.d.ts",
   "files": [
     "lib",
     "README.md",
@@ -58,7 +61,9 @@
     "mocha": "^2.4.5",
     "promise": "^7.1.1",
     "redux": "^3.5.1",
+    "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.6",
-    "symbol-observable": "^0.2.4"
+    "symbol-observable": "^0.2.4",
+    "typescript": "^1.8.10"
   }
 }

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,0 +1,9 @@
+import { reduxObservable, ActionsObservable } from '../index';
+import { Observable } from 'rxjs/Observable';
+
+// should be a function
+reduxObservable();
+
+// should be a constructor that returns an observable
+const actionsSubject = Observable.create(() => {});
+const aoTest: Observable<string> = new ActionsObservable(actionsSubject);


### PR DESCRIPTION
Here's an attempt at providing typings for (#12).  There are a number of different ways of doing typings, I took the approach that seemed easiest.  I would be happy to modify the typings into alternate styles, or configurations as I made a lot of assumptions. 

- adds a new `index.d.ts` file which has the typings
- adds a `typings` property in `package.json` which points to `index.d.ts`
- adds a `test/typings.ts` file which attempts to use the typings
- adds an `npm run clean` task to remove `lib` and `temp`
- adds an `npm run test_typings` task to encapsulate the typescript test command
- adds `rimraf` and `typescript` as `devDependencies`
- updates `.gitignore` to exclude intelliJ files
- modifies `npm run test` so that it executes the TypeScript test
