### PR TITLE
feat(reduxObservable): allow async streams to emit other async actions

### DIFF
--- a/src/reduxObservable.js
+++ b/src/reduxObservable.js
@@ -10,7 +10,7 @@ export function reduxObservable() {
     return (action) => {
       if (typeof action === 'function') {
         let obs = from(action(actionsObs, store));
-        let sub = obs.subscribe(next);
+        let sub = obs.subscribe(store.dispatch);
         return sub;
       } else {
         actions.next(action);


### PR DESCRIPTION
Fixes #8 

Basically, instead of the middleware just passing emitted actions to _the next middleware_ we instead dispatch it to the store, which allows async action streams to emit other async actions (aka thunkservables), as well as allows recursive behavior via the `ActionsObservable`.